### PR TITLE
fix: remove problematic branch tag from metadata generation

### DIFF
--- a/.github/workflows/05-add-comment.yml
+++ b/.github/workflows/05-add-comment.yml
@@ -45,7 +45,6 @@ jobs:
                 tags: |
                     type=raw,value=05-comment
                     type=raw,value=latest,enable={{is_default_branch}}
-                    type=ref,event=branch,prefix=branch-
                     type=ref,event=pr,prefix=pr-
 
             - name: Build and push images


### PR DESCRIPTION
- Remove type=ref,event=branch to prevent Docker parsing issues
- Keep essential tags: PR, latest
- Resolves "failed to push main" error